### PR TITLE
Add in memory env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # docker-dynamodb
 A docker image for dynamodb
+
+## Environment Variables
+Set the `IN_MEMORY` env var to use an in-memory cluster instead of disk based.

--- a/run.sh
+++ b/run.sh
@@ -4,13 +4,25 @@ MAX_HEAP=${MAX_HEAP_MEMORY:-1G}
 MAX_STACK=${MAX_STACK_SIZE:-512K}
 MAX_METASPACE=${MAX_METASPACE_MEMORY:-256M}
 
-java \
-  -Xmx${MAX_HEAP} \
-  -Xss${MAX_STACK} \
-  -XX:MaxMetaspaceSize=${MAX_METASPACE} \
-  -Djava.library.path=./DynamoDBLocal_lib \
-  -jar DynamoDBLocal.jar \
-  -sharedDb \
-  -dbPath \
-  /var/dynamodb_local \
-  -port 8000
+if [ -z "$IN_MEMORY" ]; then
+  java \
+    -Xmx${MAX_HEAP} \
+    -Xss${MAX_STACK} \
+    -XX:MaxMetaspaceSize=${MAX_METASPACE} \
+    -Djava.library.path=./DynamoDBLocal_lib \
+    -jar DynamoDBLocal.jar \
+    -sharedDb \
+    -dbPath \
+    /var/dynamodb_local \
+    -port 8000
+else
+  java \
+    -Xmx${MAX_HEAP} \
+    -Xss${MAX_STACK} \
+    -XX:MaxMetaspaceSize=${MAX_METASPACE} \
+    -Djava.library.path=./DynamoDBLocal_lib \
+    -jar DynamoDBLocal.jar \
+    -inMemory \
+    -sharedDb \
+    -port 8000
+fi


### PR DESCRIPTION
Allow using the -inMemory option for DynamoDB by setting the IN_MEMORY env var for the container.  

This is great for local tests, allows them to run much faster.